### PR TITLE
Improvements: helicopter/part2

### DIFF
--- a/Helicopter/Helicopter.ass
+++ b/Helicopter/Helicopter.ass
@@ -100,41 +100,41 @@ Dialogue: 0,0:02:07.29,0:02:10.68,Chinese,,0,0,0,,
 Dialogue: 0,0:02:10.68,0:02:11.97,English,,0,0,0,,and the ambient wind.
 Dialogue: 0,0:02:10.68,0:02:11.97,Chinese,,0,0,0,,
 Dialogue: 0,0:02:14.13,0:02:18.99,English,,0,0,0,,Now the setup looks pretty simple, but few people agree on what the right answer should be.
-Dialogue: 0,0:02:14.13,0:02:18.99,Chinese,,0,0,0,,题目条件看似非常简单 但关于正确答案人们却莫衷一是
+Dialogue: 0,0:02:14.13,0:02:18.99,Chinese,,0,0,0,,题目条件看似非常简单  但关于正确答案人们却莫衷一是
 Dialogue: 0,0:02:20.29,0:02:22.05,English,,0,0,0,,When I polled YouTube,
 Dialogue: 0,0:02:20.29,0:02:22.05,Chinese,,0,0,0,,我在 YouTube 上发布投票的时候
 Dialogue: 0,0:02:22.05,0:02:23.62,English,,0,0,0,, the most common answer was C.
 Dialogue: 0,0:02:22.05,0:02:23.62,Chinese,,0,0,0,,最常见的选项是 C
 Dialogue: 0,0:02:26.84,0:02:29.85,English,,0,0,0,,Well done on making that beautiful bell curve by the way.
-Dialogue: 0,0:02:26.84,0:02:29.85,Chinese,,0,0,0,,顺便一提 这条钟型曲线画得漂亮
+Dialogue: 0,0:02:26.84,0:02:29.85,Chinese,,0,0,0,,顺便一提  这条钟型曲线画得漂亮
 Dialogue: 0,0:02:29.85,0:02:32.25,English,,0,0,0,,We got in touch with the question's author,
 Dialogue: 0,0:02:29.85,0:02:32.25,Chinese,,0,0,0,,我们和问题的提出者 Paul Stanley 教授
 Dialogue: 0,0:02:32.25,0:02:33.88,English,,0,0,0,,Professor Paul Stanley.
 Dialogue: 0,0:02:32.25,0:02:33.88,Chinese,,0,0,0,,取得了联系
 Dialogue: 0,0:02:33.88,0:02:37.58,English,,0,0,0,,There was some creative students who actually constructed
-Dialogue: 0,0:02:33.88,0:02:37.58,Chinese,,0,0,0,,有些异想天开的学生其实构想了
+Dialogue: 0,0:02:33.88,0:02:37.58,Chinese,,0,0,0,,有些异想天开的学生其实已经构造了
 Dialogue: 0,0:02:37.58,0:02:40.20,English,,0,0,0,,their own homemade scenarios.
-Dialogue: 0,0:02:37.58,0:02:40.20,Chinese,,0,0,0,,他们自己的情境
+Dialogue: 0,0:02:37.58,0:02:40.20,Chinese,,0,0,0,,他们自己的模拟场景
 Dialogue: 0,0:02:40.20,0:02:43.56,English,,0,0,0,,One had a fan to the side
-Dialogue: 0,0:02:40.20,0:02:43.56,Chinese,,0,0,0,,侧面有一个旋翼
+Dialogue: 0,0:02:40.20,0:02:43.56,Chinese,,0,0,0,,侧面有一个风扇
 Dialogue: 0,0:02:43.56,0:02:46.72,English,,0,0,0,,and another fan blowing downward
-Dialogue: 0,0:02:43.56,0:02:46.72,Chinese,,0,0,0,,另一个螺旋桨则往下吹
+Dialogue: 0,0:02:43.56,0:02:46.72,Chinese,,0,0,0,,另一个风扇从上往下吹
 Dialogue: 0,0:02:46.72,0:02:49.17,English,,0,0,0,,so that they could mimic the motion of the helicopter
 Dialogue: 0,0:02:46.72,0:02:49.17,Chinese,,0,0,0,,这样他们就能模拟直升机的运动
 Dialogue: 0,0:02:49.17,0:02:51.98,English,,0,0,0,,and suspended a string and said, "Oh, it's this design."
-Dialogue: 0,0:02:49.17,0:02:51.98,Chinese,,0,0,0,,然后在上面悬挂一条绳子 他们说 哦 就是这种设计
+Dialogue: 0,0:02:49.17,0:02:51.98,Chinese,,0,0,0,,然后在上面悬挂一条绳子  他们说  噢  就是这样
 Dialogue: 0,0:02:51.98,0:02:54.50,English,,0,0,0,,And the faculty members looked at it and said,
 Dialogue: 0,0:02:51.98,0:02:54.50,Chinese,,0,0,0,,我们的教授看到之后说
 Dialogue: 0,0:02:54.50,0:02:59.25,English,,0,0,0,," Oh , obviously I can prove that the answer is this answer."
-Dialogue: 0,0:02:54.50,0:02:59.25,Chinese,,0,0,0,,哦 我能证明显然这个就是正确答案
+Dialogue: 0,0:02:54.50,0:02:59.25,Chinese,,0,0,0,,哦  显然我能证明这个就是正确答案
 Dialogue: 0,0:02:59.25,0:03:02.84,English,,0,0,0,,They just didn't agree with each other.
 Dialogue: 0,0:02:59.25,0:03:02.84,Chinese,,0,0,0,,但他们之间的意见却不能统一
 Dialogue: 0,0:03:02.84,0:03:05.16,English,,0,0,0,,- If we approximated as a chain of rigid links
-Dialogue: 0,0:03:02.84,0:03:05.16,Chinese,,0,0,0,,- 如果我们把它近似看作一串互相连接的刚体
+Dialogue: 0,0:03:02.84,0:03:05.16,Chinese,,0,0,0,,- 如果我们把它近似看作一串相互连接的刚体
 Dialogue: 0,0:03:05.16,0:03:06.51,English,,0,0,0,,- I don't think you can just do that.
 Dialogue: 0,0:03:05.16,0:03:06.51,Chinese,,0,0,0,,- 我不觉得你能那么做
 Dialogue: 0,0:03:06.51,0:03:07.34,English,,0,0,0,,- What do you think?
-Dialogue: 0,0:03:06.51,0:03:07.34,Chinese,,0,0,0,,- 你的意见如何
+Dialogue: 0,0:03:06.51,0:03:07.34,Chinese,,0,0,0,,- 你怎么看
 Dialogue: 0,0:03:07.34,0:03:09.42,English,,0,0,0,,- I think you're more likely to be C.
 Dialogue: 0,0:03:07.34,0:03:09.42,Chinese,,0,0,0,,- 我觉得答案更像是 C
 Dialogue: 0,0:03:09.42,0:03:12.55,English,,0,0,0,,- I think it is D. - D?
@@ -152,29 +152,29 @@ Dialogue: 0,0:03:20.98,0:03:23.23,Chinese,,0,0,0,,你锁定你的选项了吗
 Dialogue: 0,0:03:26.13,0:03:29.37,English,,0,0,0,,To make sure the rope doesn't come up into the rotors of the helicopter,
 Dialogue: 0,0:03:26.13,0:03:29.37,Chinese,,0,0,0,,为了保证绳子不被卷进直升机的螺旋桨
 Dialogue: 0,0:03:29.37,0:03:32.94,English,,0,0,0,,pilot Craig wanted to keep the rope on our right side
-Dialogue: 0,0:03:29.37,0:03:32.94,Chinese,,0,0,0,,飞行员 Craig 希望让我们把绳子放在右侧
+Dialogue: 0,0:03:29.37,0:03:32.94,Chinese,,0,0,0,,飞行员 Craig 让我们把绳子放在右侧
 Dialogue: 0,0:03:32.94,0:03:34.44,English,,0,0,0,,so he could keep an eye on it.
-Dialogue: 0,0:03:32.94,0:03:34.44,Chinese,,0,0,0,,这样他可以留意到
+Dialogue: 0,0:03:32.94,0:03:34.44,Chinese,,0,0,0,,方便他多加留意
 Dialogue: 0,0:03:36.39,0:03:37.65,English,,0,0,0,,Looks pretty good.
 Dialogue: 0,0:03:36.39,0:03:37.65,Chinese,,0,0,0,,看起来不错
 Dialogue: 0,0:03:37.65,0:03:38.85,English,,0,0,0,,- I'm trying to make it look good.
 Dialogue: 0,0:03:37.65,0:03:38.85,Chinese,,0,0,0,,- 我正在试着让它保持稳定
 Dialogue: 0,0:03:38.85,0:03:40.89,English,,0,0,0,,I mean I'm really working on it.
-Dialogue: 0,0:03:38.85,0:03:40.89,Chinese,,0,0,0,,我的意思是我正在做这件事
+Dialogue: 0,0:03:38.85,0:03:40.89,Chinese,,0,0,0,,我的意思是我很努力了
 Dialogue: 0,0:03:40.89,0:03:42.41,English,,0,0,0,,- You're working hard.
 Dialogue: 0,0:03:40.89,0:03:42.41,Chinese,,0,0,0,,- 辛苦你了
 Dialogue: 0,0:03:42.41,0:03:44.91,English,,0,0,0,,So, we're not going straight forward.
-Dialogue: 0,0:03:42.41,0:03:44.91,Chinese,,0,0,0,,所以 我们不会向正前方飞行
+Dialogue: 0,0:03:42.41,0:03:44.91,Chinese,,0,0,0,,我们不会向正前方飞行
 Dialogue: 0,0:03:44.91,0:03:49.51,English,,0,0,0,,We're actually going diagonally forward and to the left.
 Dialogue: 0,0:03:44.91,0:03:49.51,Chinese,,0,0,0,,实际上我们在往左前方运动
 Dialogue: 0,0:03:53.68,0:03:56.71,English,,0,0,0,,But you can clearly see the rope is hanging straight,
 Dialogue: 0,0:03:53.68,0:03:56.71,Chinese,,0,0,0,,但是你能明显看到悬挂的绳子
 Dialogue: 0,0:03:56.71,0:03:58.31,English,,0,0,0,,diagonally to the left.
-Dialogue: 0,0:03:56.71,0:03:58.31,Chinese,,0,0,0,,呈一条偏向左边的直线
+Dialogue: 0,0:03:56.71,0:03:58.31,Chinese,,0,0,0,,是一条向左的斜直线
 Dialogue: 0,0:03:59.24,0:04:00.99,English,,0,0,0,,That's a pretty good diagonal, man.
-Dialogue: 0,0:03:59.24,0:04:00.99,Chinese,,0,0,0,,这条斜着的直线基本没有弯曲
+Dialogue: 0,0:03:59.24,0:04:00.99,Chinese,,0,0,0,,哇哦  完美的斜线
 Dialogue: 0,0:04:02.92,0:04:05.54,English,,0,0,0,,So, the correct answer to the question is B.
-Dialogue: 0,0:04:02.92,0:04:05.54,Chinese,,0,0,0,,所以 正确答案是 B
+Dialogue: 0,0:04:02.92,0:04:05.54,Chinese,,0,0,0,,所以  正确答案是 B
 Dialogue: 0,0:04:09.01,0:04:09.97,English,,0,0,0,,You wanna pull it in?
 Dialogue: 0,0:04:09.01,0:04:09.97,Chinese,,0,0,0,,你要把它收回来么？
 Dialogue: 0,0:04:09.97,0:04:11.14,English,,0,0,0,,- Up it comes.

--- a/Helicopter/Helicopter.ass
+++ b/Helicopter/Helicopter.ass
@@ -130,7 +130,7 @@ Dialogue: 0,0:02:54.50,0:02:59.25,Chinese,,0,0,0,,哦 我能证明显然这个�
 Dialogue: 0,0:02:59.25,0:03:02.84,English,,0,0,0,,They just didn't agree with each other.
 Dialogue: 0,0:02:59.25,0:03:02.84,Chinese,,0,0,0,,但他们之间的意见却不能统一
 Dialogue: 0,0:03:02.84,0:03:05.16,English,,0,0,0,,- If we approximated as a chain of rigid links
-Dialogue: 0,0:03:02.84,0:03:05.16,Chinese,,0,0,0,,- 如果我们把它近似看作一串互相链接的刚体
+Dialogue: 0,0:03:02.84,0:03:05.16,Chinese,,0,0,0,,- 如果我们把它近似看作一串互相连接的刚体
 Dialogue: 0,0:03:05.16,0:03:06.51,English,,0,0,0,,- I don't think you can just do that.
 Dialogue: 0,0:03:05.16,0:03:06.51,Chinese,,0,0,0,,- 我不觉得你能那么做
 Dialogue: 0,0:03:06.51,0:03:07.34,English,,0,0,0,,- What do you think?
@@ -162,7 +162,7 @@ Dialogue: 0,0:03:37.65,0:03:38.85,Chinese,,0,0,0,,- 我正在试着让它保持�
 Dialogue: 0,0:03:38.85,0:03:40.89,English,,0,0,0,,I mean I'm really working on it.
 Dialogue: 0,0:03:38.85,0:03:40.89,Chinese,,0,0,0,,我的意思是我正在做这件事
 Dialogue: 0,0:03:40.89,0:03:42.41,English,,0,0,0,,- You're working hard.
-Dialogue: 0,0:03:40.89,0:03:42.41,Chinese,,0,0,0,,- 幸苦你了
+Dialogue: 0,0:03:40.89,0:03:42.41,Chinese,,0,0,0,,- 辛苦你了
 Dialogue: 0,0:03:42.41,0:03:44.91,English,,0,0,0,,So, we're not going straight forward.
 Dialogue: 0,0:03:42.41,0:03:44.91,Chinese,,0,0,0,,所以 我们不会向正前方飞行
 Dialogue: 0,0:03:44.91,0:03:49.51,English,,0,0,0,,We're actually going diagonally forward and to the left.


### PR DESCRIPTION
- improvements for `helicopter/part2`
- fix typo
    - `0:03:02.84` 钢体 &rarr; 刚体
    - `0:03:40.89` 幸苦 &rarr; 辛苦